### PR TITLE
Adicionada rotina para remoção de cometários

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,12 +659,12 @@ def comentarios():
             data = request.get_json()
             comentario = Comentario.query.filter_by(id=data['comentario_id']).first()
             usuario = Usuario.query.filter_by(user_name=data['username']).first()
-            privilegio_adm = Privilegio.query.filter_by(id='Admin').first()
+            privilegio_adm = Privilegio.query.filter_by(user_type='Admin').first()
 
             if not usuario or not comentario:
                 return {"error": "Informações de usuário ou comentário inválidas"}
 
-            if usuario.id == comentario.id or usuario.user_type == privilegio_adm.id:
+            if usuario.id == comentario.criador or usuario.user_type == privilegio_adm.id:
                 db.session.delete(comentario)
                 db.session.commit()
                 return {"message": "Comentário removido com sucesso"}

--- a/app.py
+++ b/app.py
@@ -625,7 +625,7 @@ def lista_postagens(id):
         except:
             return {"error": 404, "message": "Usuário não encontrado"}
 
-@app.route('/comentarios', methods=['POST', 'GET'])
+@app.route('/comentarios', methods=['POST', 'GET', 'DELETE'])
 @cross_origin(origin='*', headers=['Content-Type', 'Authorization'])
 @token_required
 def comentarios():
@@ -653,6 +653,27 @@ def comentarios():
             } for comment in comments]
 
         return {"count": len(results), "comments": results, "message": "success"}
+
+    elif request.method == 'DELETE':
+        if request.is_json:
+            data = request.get_json()
+            comentario = Comentario.query.filter_by(id=data['comentario_id']).first()
+            usuario = Usuario.query.filter_by(user_name=data['username']).first()
+            privilegio_adm = Privilegio.query.filter_by(id='Admin').first()
+
+            if not usuario:
+                return {"error": "Usuário inexistente"}
+
+            if usuario.id == comentario.id or usuario.user_type == privilegio_adm.id:
+                db.session.delete(comentario)
+                db.session.commit()
+                return {"message": "Comentário removido com sucesso"}
+
+            return {"error": "O usuário não tem autorização para essa ação"}
+        
+        else:
+            return {"error": "A requisição não está no formato esperado"}
+
 
 @app.route('/comentarios/<postagem_id>', methods=['GET'])
 @cross_origin(origin='*', headers=['Content-Type', 'Authorization'])

--- a/app.py
+++ b/app.py
@@ -661,8 +661,8 @@ def comentarios():
             usuario = Usuario.query.filter_by(user_name=data['username']).first()
             privilegio_adm = Privilegio.query.filter_by(id='Admin').first()
 
-            if not usuario:
-                return {"error": "Usuário inexistente"}
+            if not usuario or not comentario:
+                return {"error": "Informações de usuário ou comentário inválidas"}
 
             if usuario.id == comentario.id or usuario.user_type == privilegio_adm.id:
                 db.session.delete(comentario)

--- a/app.py
+++ b/app.py
@@ -712,7 +712,8 @@ def comentarios():
         if request.is_json:
             data = request.get_json()
             comentario = Comentario.query.filter_by(id=data['comentario_id']).first()
-            usuario = Usuario.query.filter_by(user_name=data['username']).first()
+            id = get_authorized_user(request)
+            usuario = Usuario.query.get(id)
             privilegio_adm = Privilegio.query.filter_by(user_type='Admin').first()
 
             if not usuario or not comentario:


### PR DESCRIPTION
### O que foi feito:
O comentário é removido através de uma request DELETE no endpoint `/comentarios`. A request deve conter o username do usuário logado e o ID do comentário a ser removido. O comentário apenas é removido se for de autoria do usuário ou se o usuário for administrador.

### Como testar:
Realizar uma request `DELETE /comentarios` com o seguinte body:
`{
    "username": <nome do usuário>,
    "comentario_id": <id do comentário>
}`

#### Cenários:
- [ ] Usuário ou comentários inexistentes: API retorna `{"error": "Informações de usuário ou comentário inválidas"}`
- [ ] Informações válidas e usuário com permissão para alterar: API retorna `{"message": "Comentário removido com sucesso"}`
- [ ] Informações válidas e usuário sem permissão para alterar: API retorna `{"error": "O usuário não tem autorização para essa ação"}`
- [ ] Conteúdo da requisição não é JSON: API retorna `{"error": "A requisição não está no formato esperado"}`